### PR TITLE
Support JVM processes in a different PID and mount namespace

### DIFF
--- a/src/jattach_linux.c
+++ b/src/jattach_linux.c
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+#ifdef __linux__
+#define _GNU_SOURCE
+#include <sched.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -66,13 +71,13 @@ static int check_socket(int pid) {
 
 // Force remote JVM to start Attach listener.
 // HotSpot will start Attach listener in response to SIGQUIT if it sees .attach_pid file
-static int start_attach_mechanism(int pid) {
+static int start_attach_mechanism(int pid, int nspid) {
     char path[PATH_MAX];
-    snprintf(path, PATH_MAX, "/proc/%d/cwd/.attach_pid%d", pid, pid);
+    snprintf(path, PATH_MAX, "/proc/%d/cwd/.attach_pid%d", nspid, nspid);
     
     int fd = creat(path, 0660);
     if (fd == -1) {
-        snprintf(path, PATH_MAX, "%s/.attach_pid%d", get_temp_directory(), pid);
+        snprintf(path, PATH_MAX, "%s/.attach_pid%d", get_temp_directory(), nspid);
         fd = creat(path, 0660);
         if (fd == -1) {
             return 0;
@@ -80,6 +85,7 @@ static int start_attach_mechanism(int pid) {
     }
     close(fd);
     
+    // We have to still use the host namespace pid here for the kill() call
     kill(pid, SIGQUIT);
     
     int result;
@@ -87,7 +93,7 @@ static int start_attach_mechanism(int pid) {
     int retry = 0;
     do {
         nanosleep(&ts, NULL);
-        result = check_socket(pid);
+        result = check_socket(nspid);
     } while (!result && ++retry < 10);
 
     unlink(path);
@@ -138,6 +144,65 @@ static void read_response(int fd) {
     }
 }
 
+// On Linux, get the innermost pid namespace pid for the specified host pid
+static int nspid_for_pid(int pid) {
+#ifdef __linux__
+    int nspid = pid;
+    char status[64];
+    char *line = NULL;
+    FILE *status_file;
+    size_t size;
+
+    snprintf(status, sizeof(status), "/proc/%d/status", pid);
+    status_file = fopen(status, "r");
+
+    while (getline(&line, &size, status_file) != -1) {
+        if (strstr(line, "NStgid:") != NULL) {
+            // PID namespaces can be nested; the last one is the innermost one
+            nspid = (int)strtol(strrchr(line, '\t'), NULL, 10);
+        }
+    }
+
+    if (line != NULL) {
+        free(line);
+    }
+    fclose(status_file);
+    return nspid;
+#else
+    return pid;
+#endif
+}
+
+static int enter_mount_ns(int pid) {
+#ifdef __linux__
+    // We're leaking the oldns and newns descriptors, but this is a short-running
+    // tool, so they will be closed when the process exits anyway.
+    int oldns, newns;
+    char curnspath[128], newnspath[128];
+    struct stat oldns_stat, newns_stat;
+
+    snprintf(curnspath, sizeof(curnspath), "/proc/self/ns/mnt");
+    snprintf(newnspath, sizeof(newnspath), "/proc/%d/ns/mnt", pid);
+
+    if ((oldns = open(curnspath, O_RDONLY)) < 0 ||
+        ((newns = open(newnspath, O_RDONLY)) < 0)) {
+        return 0;
+    }
+
+    if (fstat(oldns, &oldns_stat) < 0 || fstat(newns, &newns_stat) < 0) {
+        return 0;
+    }
+    if (oldns_stat.st_ino == newns_stat.st_ino) {
+        // Don't try to call setns() if we're in the same namespace already.
+        return 1;
+    }
+
+    return setns(newns, CLONE_NEWNS) < 0 ? 0 : 1;
+#else
+    return 1;
+#endif
+}
+
 int main(int argc, char** argv) {
     if (argc < 3) {
         printf("Usage: jattach <pid> <cmd> <args> ...\n");
@@ -150,15 +215,20 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    int nspid = nspid_for_pid(pid);
+    if (enter_mount_ns(pid) < 0) {
+        fprintf(stderr, "WARNING: couldn't enter target process mnt namespace\n");
+    }
+
     // Make write() return EPIPE instead of silent process termination
     signal(SIGPIPE, SIG_IGN);
 
-    if (!check_socket(pid) && !start_attach_mechanism(pid)) {
+    if (!check_socket(nspid) && !start_attach_mechanism(pid, nspid)) {
         perror("Could not start attach mechanism");
         return 1;
     }
 
-    int fd = connect_socket(pid);
+    int fd = connect_socket(nspid);
     if (fd == -1) {
         perror("Could not connect to socket");
         return 1;
@@ -176,6 +246,6 @@ int main(int argc, char** argv) {
 
     printf("\n");
     close(fd);
-    
+
     return 0;
 }


### PR DESCRIPTION
Containers are typically isolated behind a different PID namespace
and a different mount namespace from the host. As a result, certain
things in jattach's operation will not work:

- Creating the attach_pid file will fail, or create the file in the
  wrong directory (ignoring the target's mount namespace)

- Looking for the java_pid file will fail (again, wrong namespace)

- The pid value in the attach_pid and java_pid files will be the
  host's pid and not the pid the JVM considers to be its pid

These issues are fixable by making jattach enter the mount namespace
of the target process prior to creating the attach_pid file and
waiting for the java_pid socket to appear. Also, jattach now resolves
the target's pid by traversing /proc/$PID/status to find the inner-
most pid namespace pid.

Tested manually by running a Java application in a Docker container,
and running jattach from the host using the host's pid for the Java
process as the target.

Resolves #10.