### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@ ifneq ($(findstring Windows,$(OS)),)
   CL=cl.exe
   CFLAGS=/O2 /D_CRT_SECURE_NO_WARNINGS
   JATTACH_EXE=jattach.exe
+else 
+	UNAME_S := $(shell uname -s)
+ifneq ($(findstring FreeBSD,$(UNAME_S)),)
+  CC=cc
+  CFLAGS=-O2
+  JATTACH_EXE=jattach
 else
   ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
   RPM_ROOT=$(ROOT_DIR)/build/rpm
@@ -10,6 +16,7 @@ else
   CC=gcc
   CFLAGS=-O2
   JATTACH_EXE=jattach
+endif
 endif
 
 all: build build/$(JATTACH_EXE)


### PR DESCRIPTION
Hi,

FreeBSD uses clang since FreeBSD 10 as default compiler for kernel/userland. So Makefile should handle use clang instead of gcc on this platform. 

Tested (compilation & execution) on FreeBSD 12-CURRENT:

$ gmake clean
rm -rf build
$ gmake all
mkdir -p build
cc -O2 -o build/jattach src/jattach_linux.c
$ 