### PR TITLE
Support getting of process info on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,16 @@ https://docs.oracle.com/javase/8/docs/jdk/api/attach/spec/
 Where `true` means that the path is absolute, `false` -- the path is relative.
 
 `options` are passed to the agent.
+
+### Installation
+#### FreeBSD
+
+On FreeBSD, you can use the following command to install `jattach` package:
+
+    $ pkg install jattach
+
+#### Alpine Linux
+
+On Alpine Linux, you can use the following command to install `jattach` package from the edge/testing repository:
+
+    $ apk add --no-cache jattach --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/


### PR DESCRIPTION
Hi,

jattach compilation is broke on FreeBSD:

```
$ gmake all
cc -O2 -o build/jattach src/jattach_linux.c
src/jattach_linux.c:134:20: error: use of undeclared identifier '__NR_setns'
    return syscall(__NR_setns, newns, 0) < 0 ? 0 : 1;
                   ^
1 error generated.
gmake: *** [Makefile:28: build/jattach] Error 1
```
I added the following functions for FreeBSD platform:

* `get_process_info()` - implementation
* `enter_mount_ns()` - stub
* `alt_lookup_nspid()` - stub

Tested (compilation & execution) on FreeBSD 12-CURRENT: