### PR TITLE
Refactor for static lib.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ else
   endif
 endif
 
+LIB_JATTACH_SRCS := $(filter-out main.c, $(notdir $(wildcard src/posix/*.c)))
+LIB_JATTACH_OBJS := $(patsubst %.c, build/lib/%.o, $(LIB_JATTACH_SRCS))
 
 .PHONY: all dll clean rpm-dirs rpm
 
@@ -33,9 +35,15 @@ all: build build/$(JATTACH_EXE)
 dll: build build/$(JATTACH_DLL)
 
 build:
-	mkdir -p build
+	mkdir -p build/lib
 
-build/jattach: src/posix/*.c src/posix/*.h
+build/lib/%.o: src/posix/%.c src/posix/*.h build
+	$(CC) $(CFLAGS) -o $@ -c $<
+
+build/lib/jattach.a: $(LIB_JATTACH_OBJS)
+	ar rvs $@ $^
+
+build/jattach: src/posix/main.c build/lib/jattach.a
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -DJATTACH_VERSION=\"$(JATTACH_VERSION)\" -o $@ src/posix/*.c
 
 build/$(JATTACH_DLL): src/posix/*.c src/posix/*.h

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ else
 endif
 
 LIB_JATTACH_SRCS := $(filter-out main.c, $(notdir $(wildcard src/posix/*.c)))
-LIB_JATTACH_OBJS := $(patsubst %.c, build/lib/%.o, $(LIB_JATTACH_SRCS))
+LIB_JATTACH_OBJS := $(patsubst %.c, build/%.o, $(LIB_JATTACH_SRCS))
 
 .PHONY: all dll clean rpm-dirs rpm
 
@@ -35,15 +35,15 @@ all: build build/$(JATTACH_EXE)
 dll: build build/$(JATTACH_DLL)
 
 build:
-	mkdir -p build/lib
+	mkdir -p build
 
-build/lib/%.o: src/posix/%.c src/posix/*.h build
+build/%.o: src/posix/%.c src/posix/*.h build
 	$(CC) $(CFLAGS) -o $@ -c $<
 
-build/lib/jattach.a: $(LIB_JATTACH_OBJS)
+build/jattach.a: $(LIB_JATTACH_OBJS)
 	ar rvs $@ $^
 
-build/jattach: src/posix/main.c build/lib/jattach.a
+build/jattach: src/posix/main.c build/jattach.a
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -DJATTACH_VERSION=\"$(JATTACH_VERSION)\" -o $@ src/posix/*.c
 
 build/$(JATTACH_DLL): src/posix/*.c src/posix/*.h

--- a/src/posix/jattach.c
+++ b/src/posix/jattach.c
@@ -15,7 +15,6 @@
  */
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <signal.h>
 #include <unistd.h>
 #include "psutil.h"
@@ -62,27 +61,4 @@ int jattach(int pid, int argc, char** argv) {
     } else {
         return jattach_hotspot(pid, nspid, argc, argv);
     }
-}
-
-int main(int argc, char** argv) {
-    if (argc < 3) {
-        printf("jattach " JATTACH_VERSION " built on " __DATE__ "\n"
-               "Copyright 2021 Andrei Pangin\n"
-               "\n"
-               "Usage: jattach <pid> <cmd> [args ...]\n"
-               "\n"
-               "Commands:\n"
-               "    load  threaddump   dumpheap  setflag    properties\n"
-               "    jcmd  inspectheap  datadump  printflag  agentProperties\n"
-               );
-        return 1;
-    }
-
-    int pid = atoi(argv[1]);
-    if (pid <= 0) {
-        fprintf(stderr, "%s is not a valid process ID\n", argv[1]);
-        return 1;
-    }
-
-    return jattach(pid, argc - 2, argv + 2);
 }

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Andrei Pangin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int jattach(int pid, int argc, char** argv);
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        printf("jattach " JATTACH_VERSION " built on " __DATE__ "\n"
+               "Copyright 2021 Andrei Pangin\n"
+               "\n"
+               "Usage: jattach <pid> <cmd> [args ...]\n"
+               "\n"
+               "Commands:\n"
+               "    load  threaddump   dumpheap  setflag    properties\n"
+               "    jcmd  inspectheap  datadump  printflag  agentProperties\n"
+               );
+        return 1;
+    }
+
+    int pid = atoi(argv[1]);
+    if (pid <= 0) {
+        fprintf(stderr, "%s is not a valid process ID\n", argv[1]);
+        return 1;
+    }
+
+    return jattach(pid, argc - 2, argv + 2);
+}


### PR DESCRIPTION
Extract `main()` into its own file such that jattach can be compiled into a static lib. for use in other projects. Makefile is updated such that a static lib is created and the shared lib (dll) target remains available also.