### PR TITLE
Free buffer on read error in jattach_openj9.c

### DIFF
--- a/src/posix/jattach_openj9.c
+++ b/src/posix/jattach_openj9.c
@@ -125,9 +125,11 @@ static int read_response(int fd, const char* cmd, int print_output) {
         ssize_t bytes = read(fd, buf + off, size - off);
         if (bytes == 0) {
             fprintf(stderr, "Unexpected EOF reading response\n");
+            free(buf);
             return 1;
         } else if (bytes < 0) {
             perror("Error reading response");
+            free(buf);
             return 1;
         }
 


### PR DESCRIPTION
Hello :)

This patch ensures that the allocated buffer in `read_response()` is properly freed when `read()` fails or returns `0`

Thanks for reviewing.