### PR TITLE
Avoid jattach waiting for an already dead process

### DIFF
--- a/src/posix/jattach_hotspot.c
+++ b/src/posix/jattach_hotspot.c
@@ -63,7 +63,7 @@ static int start_attach_mechanism(int pid, int nspid) {
     do {
         nanosleep(&ts, NULL);
         result = check_socket(nspid);
-    } while (result != 0 && (ts.tv_nsec += 20000000) < 500000000);
+    } while (result != 0 && (ts.tv_nsec += 20000000) < 500000000 && kill(pid, 0) == 0);
 
     unlink(path);
     return result;


### PR DESCRIPTION
# Description 

While doing some various tests on async-profiler I noticed that it's possible for two different race conditions to happen around this `do-while` loop

* If attach happens too early, the JVM process wouldn't have installed it's signal handlers so the `kill(pid, SIGQUIT)` will kill the process 
* If attach happens too late, it's possible for the process to die after the file descriptor is created 

In both cases the jattach command here will basically do a busy wait for 6 seconds as the process it's trying to attach to no longer exists 

By adding the `kill(pid, 0) == 0` condition that effect will be minimized 

# Motivation and context

Do not let jattach wait for an already dead process 
 
------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).